### PR TITLE
Fix: Rebuild Machine Flow

### DIFF
--- a/web/app/components/gpu-form.tsx
+++ b/web/app/components/gpu-form.tsx
@@ -72,7 +72,7 @@ export default function GpuForm({
                 name="machine_name"
                 placeholder="Machine name"
                 defaultValue={machineName}
-                disabled={!!machineName}
+                className={machineName ? "cursor-not-allowed opacity-50" : ""}
                 readOnly={!!machineName}
                 onChange={(e) => {
                   if (machineNameRegex.test(e.target.value)) {


### PR DESCRIPTION
**Issue:**
The rebuild machine flow was failing as the disabled "machine_name" input field wasn't being sent in the FormData by Remix. This is because Remix won't send disabled input values in FormData.

**Fix:**
Removed disabled parameter during rebuild. We're instead using CSS to make input field look disabled for editing