### PR TITLE
Fix: Set type to "custom" for models downloaded via  HF url

### DIFF
--- a/web/app/components/models-form.tsx
+++ b/web/app/components/models-form.tsx
@@ -309,7 +309,7 @@ function AddCustomModelDialog({ onModelSaved }: AddCustomModelDialogProps) {
                   !isValidUrl ? "opacity-100" : "opacity-0"
                 }`}
               >
-                Please enter a valid URL
+                Please enter a valid download url from HuggingFace
               </p>
             </div>
           </div>

--- a/web/app/lib/utils.ts
+++ b/web/app/lib/utils.ts
@@ -113,7 +113,8 @@ export function formatRelativeTime(dateTimeString: string): string {
 
 export function isValidModelUrl(url: string): boolean {
   const validExtensions = [".ckpt", ".safetensors", ".pt", ".pth", ".bin"];
-  const urlRegex = /^https?:\/\/.+/i;
+  const urlRegex =
+    /^(https?:\/\/)?([\da-z.-]+\.)*huggingface\.co([/\w .-]*)*\/?$/;
   if (!urlRegex.test(url)) {
     return false;
   }


### PR DESCRIPTION
- Set model type to "custom" as our utils maps it to "checkpoints" if not type is set
- Add HF url validation to prevent users from entering any other download link