### PR TITLE
Fix: Use filename option to specify model file name when downloading

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -19,6 +19,7 @@ class Model(BaseModel):
     name: str
     url: HttpUrl
     path: str
+    filename: Optional[str]
 
 
 class Gpu(str, Enum):

--- a/backend/src/template/helpers.py
+++ b/backend/src/template/helpers.py
@@ -4,22 +4,11 @@ import shutil
 import os
 from modal import (Volume)
 
-models_volume = Volume.from_name("model-checkpoints", create_if_missing=True)
+models_volume = Volume.from_name("comfyui-models", create_if_missing=True)
 
 MOUNT_PATH: Path = Path("/mnt")
 MODELS_PATH: Path = MOUNT_PATH / "models"
 
-
-CLIP_VISION_ROOT_PATH: Path = Path("/mnt/models/clip_vision")
-SOURCE_CLIP_VISION_BIG_PATH: Path = CLIP_VISION_ROOT_PATH / \
-    "ipadapter-clip-vision-big/model.safetensors"
-SOURCE_CLIP_VISION_SMALL_PATH: Path = CLIP_VISION_ROOT_PATH / \
-    "ipadapter-clip-vision-small/model.safetensors"
-
-DEST_CLIP_VISION_BIG_PATH: Path = CLIP_VISION_ROOT_PATH / \
-    "CLIP-ViT-bigG-14-laion2B-39B-b160k.safetensors"
-DEST_CLIP_VISION_SMALL_PATH: Path = CLIP_VISION_ROOT_PATH / \
-    "CLIP-ViT-H-14-laion2B-s32B-b79K.safetensors"
 
 ANTELOPEV2_MODEL_ZIP_PATH: Path = Path(
     "/mnt/models/insightface/models/antelopev2.zip")
@@ -35,21 +24,24 @@ def download_models(models, civitai_token) -> bool:
         model_name = model["name"]
         download_url = model["url"]
         download_path = model["path"]
-        file_name = download_url.split("/")[-1]
-        if CIVITAI_BASE_URL in download_url or file_name in common_model_names:
+        file_name = model.get("filename", download_url.split("/")[-1])
+        print(f"file_name: {file_name}")
+        if file_name in common_model_names:
             checkpoint_path: Path = Path(
                 f"/mnt/models/{download_path}") / model_name
             relative_path: Path = checkpoint_path
         else:
             checkpoint_path: Path = Path(
                 f"/mnt/models/{download_path}") / file_name
-            relative_path = Path(download_path)
+            relative_path = Path(f"/mnt/models/{download_path}")
         print(f"checkpoint_path: {checkpoint_path}")
         print(f"checkpoint_path exists : {checkpoint_path.exists()}")
 
+        print(f"relative_path: {relative_path}")
+
         if not checkpoint_path.exists():
             print(f"Downloading {model_name} ....")
-            cmd = f"comfy --skip-prompt model download --url {download_url} --relative-path {relative_path} --set-civitai-api-token {civitai_token}"
+            cmd = f"comfy --skip-prompt model download --url {download_url} --relative-path {relative_path} --filename {file_name} --set-civitai-api-token {civitai_token}"
             download_process = subprocess.Popen(
                 cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             # Wait for the process to complete
@@ -65,16 +57,6 @@ def download_models(models, civitai_token) -> bool:
         else:
             print(f"skipping download of {model_name}. File exists")
     return True
-
-
-def move_clip_vision_files():
-    if SOURCE_CLIP_VISION_BIG_PATH.exists() and not DEST_CLIP_VISION_BIG_PATH.exists():
-        print(f"Moving big clip vision model to {DEST_CLIP_VISION_BIG_PATH}")
-        shutil.move(SOURCE_CLIP_VISION_BIG_PATH, DEST_CLIP_VISION_BIG_PATH)
-    if SOURCE_CLIP_VISION_SMALL_PATH.exists() and not DEST_CLIP_VISION_SMALL_PATH.exists():
-        print(
-            f"Moving small clip vision model to {DEST_CLIP_VISION_SMALL_PATH}")
-        shutil.move(SOURCE_CLIP_VISION_SMALL_PATH, DEST_CLIP_VISION_SMALL_PATH)
 
 
 def unzip_insight_face_models():

--- a/backend/src/template/workflow.py
+++ b/backend/src/template/workflow.py
@@ -11,7 +11,7 @@ from helpers import (models_volume, MODELS_PATH, MOUNT_PATH,
 
 current_directory = os.path.dirname(os.path.realpath(__file__))
 
-default_dependencies = "comfy-cli==1.0.34"
+default_dependencies = "comfy-cli==1.0.36"
 additional_dependencies = config["additional_dependencies"]
 dependencies_str = default_dependencies if not additional_dependencies else f"{default_dependencies}, {additional_dependencies}"
 dependencies: list[str] = [item.strip()

--- a/backend/src/template/workflow.py
+++ b/backend/src/template/workflow.py
@@ -4,9 +4,9 @@ import json
 import os
 from config import config
 
-from modal import (App, gpu, Image, web_server, build, enter, Secret)
+from modal import (App, Image, web_server, build, Secret)
 from helpers import (models_volume, MODELS_PATH, MOUNT_PATH,
-                     download_models, move_clip_vision_files,  unzip_insight_face_models)
+                     download_models,  unzip_insight_face_models)
 
 
 current_directory = os.path.dirname(os.path.realpath(__file__))
@@ -21,6 +21,7 @@ comfyui_image = (Image.debian_slim(python_version="3.10")
                  .apt_install("git")
                  .pip_install(dependencies)
                  .run_commands("comfy --skip-prompt install --nvidia")
+                 .run_commands("comfy --version")
                  .copy_local_file(f"{current_directory}/custom_nodes.json", "/root/")
                  .run_commands("comfy --skip-prompt node install-deps --deps=/root/custom_nodes.json")
                  .copy_local_file(f"{current_directory}/models.json", "/root/")
@@ -35,7 +36,7 @@ app = App(
     machine_name,
     image=comfyui_image,
     volumes={
-        MOUNT_PATH: models_volume
+        MODELS_PATH: models_volume
     },
     secrets=[Secret.from_name("civitai-secret")]
 )
@@ -57,15 +58,14 @@ class ComfyWorkflow:
         with open("/root/models.json", 'r', encoding='utf-8') as file:
             models = json.load(file)
             downloaded = download_models(models, os.environ["CIVITAI_TOKEN"])
-            move_clip_vision_files()
-            unzip_insight_face_models()
+            models_volume.commit()
             if downloaded:
-                models_volume.commit()
                 print(
                     "Copying models to correct directory - This might take a few more seconds")
                 shutil.copytree(
                     MODELS_PATH, "/root/comfy/ComfyUI/models", dirs_exist_ok=True)
                 print("Models copied!!")
+                unzip_insight_face_models()
 
     def _run_comfyui_server(self, port=8188):
         cmd = f"comfy --skip-prompt launch -- --listen 0.0.0.0 --port {port}"

--- a/web/app/components/models-form.tsx
+++ b/web/app/components/models-form.tsx
@@ -345,7 +345,6 @@ function AddCustomModelDialog({ onModelSaved }: AddCustomModelDialogProps) {
                 return;
               }
               onModelSaved({
-                filename: name,
                 name,
                 save_path: path,
                 url,

--- a/web/app/lib/types.ts
+++ b/web/app/lib/types.ts
@@ -59,6 +59,7 @@ export interface OutputModel {
   name: string;
   url: string;
   path: string;
+  filename?: string;
 }
 
 export interface CreateAppRequestBody {

--- a/web/app/lib/types.ts
+++ b/web/app/lib/types.ts
@@ -20,7 +20,7 @@ export interface Model {
   save_path: string;
   reference: string;
   url: string;
-  filename: string;
+  filename?: string;
   base: string;
   description: string;
   size: string;

--- a/web/app/lib/utils.ts
+++ b/web/app/lib/utils.ts
@@ -59,7 +59,7 @@ export function convertCustomNodesJson(nodes: CustomNode[]) {
 
 export function convertModelsJson(input: Model[]): OutputModel[] {
   return input.map((item) => {
-    const nameWithoutExtension = item.filename.split(".")[0];
+    const nameWithoutExtension = item.name.split(".")[0];
 
     let path: string;
     if (!item.type) {
@@ -81,6 +81,7 @@ export function convertModelsJson(input: Model[]): OutputModel[] {
       name: nameWithoutExtension,
       url: item.url,
       path: path.toLocaleLowerCase(),
+      filename: item.filename,
     };
   });
 }


### PR DESCRIPTION
- Upgraded comfy-cli to latest to use `--filename` option for specifying filename during the download
- Sending model's file name when creating app
- Removed `move_clip_vision_models`  from helpers
- Updated file download logic in helpers to use filename sent for the models