### PR TITLE
Allow editing workflows on CPUs

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -175,16 +175,19 @@ async def delete_app(app_id: str):
 async def get_edit_url(app_name: str):
     try:
         workspace = await run_modal_command("modal profile current")
-        url = f"https://{workspace}--{app_name}-editingworkflow-get-tunnel-url.modal.run"
+        edit_url = f"https://{workspace}--{app_name}-editingworkflow-get-tunnel-url.modal.run"
+        run_url = f"https://{workspace}--{app_name}-comfyworkflow-ui.modal.run"
 
-        logger.info("GET request to url %s", url)
+        logger.info("GET request to url %s", edit_url)
 
         # Set a 30-second timeout
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(url)
+            response = await client.get(edit_url)
             response.raise_for_status()
             result = response.json()
+            result["run_url"] = run_url
             logger.info("Tunnel url %s", result)
+            logger.info("Run url %s", run_url)
             return result
     except httpx.ReadTimeout as e:
         logger.error(

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -171,8 +171,8 @@ async def delete_app(app_id: str):
     return {"app_id": app_id, "deleted": True}
 
 
-@app.get("/apps/{app_name}/edit-workflow", dependencies=[Depends(verify_api_key)])
-async def get_edit_url(app_name: str):
+@app.get("/apps/{app_name}/workflow-urls", dependencies=[Depends(verify_api_key)])
+async def get_workflow_urls(app_name: str):
     try:
         workspace = await run_modal_command("modal profile current")
         edit_url = f"https://{workspace}--{app_name}-editingworkflow-get-tunnel-url.modal.run"

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import os
 import json
@@ -191,16 +190,16 @@ async def get_edit_url(app_name: str):
         logger.error(
             "Request timed out while making a request to %s", e.request.url)
         raise HTTPException(
-            status_code=504, detail="Request timed out while fetching edit URL")
+            status_code=504, detail="Request timed out while fetching edit URL") from e
     except httpx.HTTPError as e:
         logger.error("HTTP %d %s error occurred while making a request to %s",
-                     e.response.status_code, e.response.reason_phrase, e.request.url)
-        logger.error("Response content: %s", e.response.text)
+                     response.status_code, response.reason_phrase, e.request.url)
         raise HTTPException(
-            status_code=500, detail=f"Failed to fetch edit URL: {str(e)}")
+            status_code=500, detail=f"Failed to fetch edit URL: {str(e)}") from e
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error")
+        raise HTTPException(
+            status_code=500, detail="Internal server error") from e
 
 
 async def deploy_app(payload: CreateAppPayload):

--- a/backend/src/template/workflow.py
+++ b/backend/src/template/workflow.py
@@ -4,7 +4,8 @@ import json
 import os
 from config import config
 
-from modal import (App, Image, web_server, build, Secret)
+from modal import (App, Image, web_server, build,
+                   Secret, method, forward, web_endpoint, Queue)
 from helpers import (models_volume, MODELS_PATH, MOUNT_PATH,
                      download_models,  unzip_insight_face_models)
 
@@ -21,7 +22,6 @@ comfyui_image = (Image.debian_slim(python_version="3.10")
                  .apt_install("git")
                  .pip_install(dependencies)
                  .run_commands("comfy --skip-prompt install --nvidia")
-                 .run_commands("comfy --version")
                  .copy_local_file(f"{current_directory}/custom_nodes.json", "/root/")
                  .run_commands("comfy --skip-prompt node install-deps --deps=/root/custom_nodes.json")
                  .copy_local_file(f"{current_directory}/models.json", "/root/")
@@ -74,3 +74,53 @@ class ComfyWorkflow:
     @web_server(8188, startup_timeout=60)
     def ui(self):
         self._run_comfyui_server()
+
+
+@app.cls(
+    cpu=4.0,
+    memory=16384,
+    image=comfyui_image,
+    timeout=300,
+)
+class EditingWorkflow:
+    @build()
+    def download(self):
+        with open("/root/models.json", 'r', encoding='utf-8') as file:
+            models = json.load(file)
+            downloaded = download_models(models, os.environ["CIVITAI_TOKEN"])
+            models_volume.commit()
+            if downloaded:
+                print(
+                    "Copying models to correct directory - This might take a few more seconds")
+                shutil.copytree(
+                    MODELS_PATH, "/root/comfy/ComfyUI/models", dirs_exist_ok=True)
+                print("Models copied!!")
+                unzip_insight_face_models()
+
+    @method()
+    def run_comfy_in_tunnel(self, q):
+        with forward(8888) as tunnel:
+            url = tunnel.url
+            print(f"Starting ComfyUI at {url}")
+            q.put(url)
+            subprocess.run(
+                [
+                    "comfy",
+                    "--skip-prompt",
+                    "launch",
+                    "--",
+                    "--cpu",
+                    "--listen",
+                    "0.0.0.0",
+                    "--port",
+                    "8888",
+                ],
+                check=False
+            )
+
+    @web_endpoint(method="GET")
+    def get_tunnel_url(self):
+        with Queue.ephemeral() as q:
+            self.run_comfy_in_tunnel.spawn(q)
+            url = q.get()
+            return {"edit_url": url}

--- a/backend/src/template/workflow.py
+++ b/backend/src/template/workflow.py
@@ -45,7 +45,7 @@ app = App(
 @app.cls(
     gpu=gpu_config,
     image=comfyui_image,
-    timeout=300,
+    timeout=idle_timeout,
     container_idle_timeout=idle_timeout,
     allow_concurrent_inputs=100,
     # Restrict to 1 container because we want to our ComfyUI session state
@@ -80,7 +80,7 @@ class ComfyWorkflow:
     cpu=4.0,
     memory=16384,
     image=comfyui_image,
-    timeout=300,
+    timeout=idle_timeout,
 )
 class EditingWorkflow:
     @build()

--- a/web/app/components/ui/alert.tsx
+++ b/web/app/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "~/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/web/app/routes/app.$appName.edit/route.tsx
+++ b/web/app/routes/app.$appName.edit/route.tsx
@@ -1,0 +1,69 @@
+import { LoaderFunctionArgs, json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { useEffect, useState } from "react";
+
+import LoadingIndicator from "~/components/loading-indicator";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const appName = params.appName;
+  const url = `${process.env.APP_BUILDER_API_BASE_URL}/apps/${appName}/edit-workflow`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        X_API_KEY: process.env.APP_BUILDER_API_KEY!,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch edit URL");
+    }
+
+    const data = await response.json();
+    console.log("Edit workflow url", data["edit_url"]);
+    return json({ editUrl: data["edit_url"] as string });
+  } catch (error) {
+    console.error("Error fetching edit workflow URL:", error);
+    return json({ error: "Failed to load edit workflow URL" }, { status: 500 });
+  }
+}
+
+export default function AppEditPage() {
+  const data = useLoaderData<typeof loader>();
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Once the edit url is loaded, wait 15 seconds before setting isLoading to false
+  // This is to prevent the iframe from loading too quickly and giving error because the tunnel is not ready
+  useEffect(() => {
+    if ("editUrl" in data) {
+      const timer = setTimeout(() => {
+        setIsLoading(false);
+      }, 15000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [data]);
+
+  if ("error" in data) {
+    return <div className="text-rose-500">{data.error}</div>;
+  }
+
+  return (
+    <div className="h-screen flex flex-col">
+      <div className="flex-grow relative">
+        {isLoading ? (
+          <LoadingIndicator />
+        ) : (
+          data.editUrl && (
+            <iframe
+              title={data.editUrl}
+              src={data.editUrl}
+              className="w-full h-full border-0"
+            />
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/app/routes/app.$appName.edit/route.tsx
+++ b/web/app/routes/app.$appName.edit/route.tsx
@@ -75,9 +75,9 @@ export default function AppEditPage() {
                 <Alert variant="default" className="pr-12 relative">
                   <AlertTitle>Heads up!</AlertTitle>
                   <AlertDescription>
-                    You can use this page to edit your workflows. Please save
-                    the workflow before closing the page. It runs on CPU to
-                    avoid GPU costs while editing your workflows.
+                    You can use this page to edit your workflows. It runs on CPU
+                    to avoid GPU costs while editing your workflows.Please save
+                    the workflow file before closing the page.
                     <br />
                     Please use this{" "}
                     <Link

--- a/web/app/routes/app.$appName.edit/route.tsx
+++ b/web/app/routes/app.$appName.edit/route.tsx
@@ -8,7 +8,7 @@ import LoadingIndicator from "~/components/loading-indicator";
 
 export async function loader({ params }: LoaderFunctionArgs) {
   const appName = params.appName;
-  const url = `${process.env.APP_BUILDER_API_BASE_URL}/apps/${appName}/edit-workflow`;
+  const url = `${process.env.APP_BUILDER_API_BASE_URL}/apps/${appName}/workflow-urls`;
 
   try {
     const response = await fetch(url, {

--- a/web/app/routes/apps/route.tsx
+++ b/web/app/routes/apps/route.tsx
@@ -255,6 +255,8 @@ function AppsLayout({ apps }: AppsLayoutProps) {
                     <div className="truncate text-sm font-medium leading-6 text-primary/80 underline">
                       <Link
                         to={`/app/${app.description}/edit`}
+                        rel="noopener noreferrer"
+                        target="_blank"
                       >
                         {app.description}
                       </Link>

--- a/web/app/routes/apps/route.tsx
+++ b/web/app/routes/apps/route.tsx
@@ -254,9 +254,7 @@ function AppsLayout({ apps }: AppsLayoutProps) {
                   <td className="py-4 pl-4 pr-8 sm:pl-6 lg:pl-8">
                     <div className="truncate text-sm font-medium leading-6 text-primary/80 underline">
                       <Link
-                        to={app.url}
-                        rel="noopener noreferrer"
-                        target="_blank"
+                        to={`/app/${app.description}/edit`}
                       >
                         {app.description}
                       </Link>


### PR DESCRIPTION
- Using [tunnels](https://modal.com/docs/guide/tunnels) feature from Modal to expose containers running on CPU for editing workflows on the go. This helps avoid paying for GPU when you just need to edit workflows
- Created `{appName}/edit` route in web to render the edit workflow url in iFrame
- Created API route `apps/{appName}/workflow-urls` which returns both edit and run workflow urls
- Added link to `app/{appName}/edit` page from `apps` page 
- Added Alert component from Shadcn
- Show Alert in edit page providing a heads up about difference between edit and run urls