### PR TITLE
Feat: App build process improvements

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -271,7 +271,9 @@ async def deploy_app(payload: CreateAppPayload):
         yield line
 
     # Yield a line indicating the start of editing workflow deployment
-    yield f"event: stdout\ndata:Now deploying editing workflow\n\n"
+    yield f"event: stdout\ndata:{'='*50}\n\n"
+    yield f"event: stdout\ndata:🚀 Now Deploying Editing Workflow 🚀\n\n"
+    yield f"event: stdout\ndata:{'='*50}\n\n"
 
     # Deploy editing workflow
     async for line in run_command_and_stream("modal deploy editing_workflow.py"):

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -231,39 +231,51 @@ async def deploy_app(payload: CreateAppPayload):
     with open(f"{folder_path}/models.json", "w", encoding='utf-8') as f:
         json.dump(jsonable_encoder(payload.models), f, indent=4)
 
-    process = await asyncio.create_subprocess_shell(
-        "modal deploy workflow.py",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=folder_path,
-        env={**os.environ,
-             "MODAL_TOKEN_ID": os.getenv("MODAL_TOKEN_ID"),
-             "MODAL_TOKEN_SECRET": os.getenv("MODAL_TOKEN_SECRET"),
-             "COLUMNS": "10000",
-             }
-    )
+    async def run_command_and_stream(command):
+        process = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=folder_path,
+            env={**os.environ,
+                 "MODAL_TOKEN_ID": os.getenv("MODAL_TOKEN_ID"),
+                 "MODAL_TOKEN_SECRET": os.getenv("MODAL_TOKEN_SECRET"),
+                 "COLUMNS": "10000",
+                 }
+        )
 
-    async def read_stream(stream, event_type):
-        while True:
-            line = await stream.readline()
-            if line:
-                yield f"event: {event_type}\ndata:{line.decode().strip()}\n\n"
-            else:
-                break
+        async def read_stream(stream, event_type):
+            while True:
+                line = await stream.readline()
+                if line:
+                    yield f"event: {event_type}\ndata:{line.decode().strip()}\n\n"
+                else:
+                    break
 
-    async def combine_streams(*streams):
-        for stream in streams:
-            async for item in stream:
-                yield item
+        async def combine_streams(*streams):
+            for stream in streams:
+                async for item in stream:
+                    yield item
 
-    stdout_stream = read_stream(process.stdout, "stdout")
-    stderr_stream = read_stream(process.stderr, "stderr")
-    combined_streams = combine_streams(stdout_stream, stderr_stream)
+        stdout_stream = read_stream(process.stdout, "stdout")
+        stderr_stream = read_stream(process.stderr, "stderr")
+        combined_streams = combine_streams(stdout_stream, stderr_stream)
 
-    async for line in combined_streams:
+        async for line in combined_streams:
+            yield line
+
+        await process.wait()
+
+    # Deploy run workflow
+    async for line in run_command_and_stream("modal deploy workflow.py"):
         yield line
 
-    await process.wait()
+    # Yield a line indicating the start of editing workflow deployment
+    yield f"event: stdout\ndata:Now deploying editing workflow\n\n"
+
+    # Deploy editing workflow
+    async for line in run_command_and_stream("modal deploy editing_workflow.py"):
+        yield line
 
 
 async def extract_nodes_from_workflow(workflow):

--- a/backend/src/template/comfy_config.py
+++ b/backend/src/template/comfy_config.py
@@ -1,0 +1,20 @@
+import os
+from modal import Image
+from config import config
+
+current_directory = os.path.dirname(os.path.realpath(__file__))
+
+default_dependencies = "comfy-cli==1.0.36"
+additional_dependencies = config["additional_dependencies"]
+dependencies_str = default_dependencies if not additional_dependencies else f"{default_dependencies}, {additional_dependencies}"
+dependencies: list[str] = [item.strip()
+                           for item in dependencies_str.split(',')]
+
+comfyui_image = (Image.debian_slim(python_version="3.10")
+                 .apt_install("git")
+                 .pip_install(dependencies)
+                 .run_commands("comfy --skip-prompt install --nvidia")
+                 .copy_local_file(f"{current_directory}/custom_nodes.json", "/root/")
+                 .run_commands("comfy --skip-prompt node install-deps --deps=/root/custom_nodes.json")
+                 .copy_local_file(f"{current_directory}/models.json", "/root/")
+                 )

--- a/backend/src/template/editing_workflow.py
+++ b/backend/src/template/editing_workflow.py
@@ -1,0 +1,69 @@
+import subprocess
+import shutil
+import os
+from config import config
+from modal import (App, build,
+                   Secret, method, forward, web_endpoint, Queue)
+from helpers import (models_volume, MODELS_PATH, unzip_insight_face_models)
+from comfy_config import comfyui_image
+
+machine_name = config["machine_name"]
+gpu_config = config["gpu"]
+idle_timeout = config["idle_timeout"]
+
+
+app = App(
+    machine_name,
+    image=comfyui_image,
+    volumes={
+        MODELS_PATH: models_volume
+    },
+    secrets=[Secret.from_name("civitai-secret")]
+)
+
+
+@app.cls(
+    cpu=4.0,
+    memory=16384,
+    image=comfyui_image,
+    timeout=idle_timeout,
+)
+class EditingWorkflow:
+    @build()
+    def download(self):
+        print("Copying models to correct directory - This might take a few more seconds")
+        shutil.copytree(
+            MODELS_PATH, "/root/comfy/ComfyUI/models", dirs_exist_ok=True)
+        print("Models copied!!")
+        unzip_insight_face_models()
+
+    @method()
+    def run_comfy_in_tunnel(self, q):
+        with forward(8888) as tunnel:
+            url = tunnel.url
+            print(f"Starting ComfyUI at {url}")
+            q.put(url)
+            subprocess.run(
+                [
+                    "comfy",
+                    "--skip-prompt",
+                    "launch",
+                    "--",
+                    "--cpu",
+                    "--listen",
+                    "0.0.0.0",
+                    "--port",
+                    "8888",
+                ],
+                check=False
+            )
+
+
+@app.function()
+@web_endpoint(method="GET")
+def get_tunnel_url():
+    workflow = EditingWorkflow()
+    with Queue.ephemeral() as q:
+        workflow.run_comfy_in_tunnel.spawn(q)
+        url = q.get()
+    return {"edit_url": url}


### PR DESCRIPTION
- Separated run and editing workflows. This is to avoid running them in parallel as it results into downloading models multiple times. If we keep them separate, we can run them sequentially when building the app
- Updated deploy process API route to sequentially deploy the run and editing worklfows
- Streaming stdout and stderr during the model download process to update logs about the current download progress