### PR TITLE
Feat: Remove tunnels for edit workflows

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -176,31 +176,16 @@ async def delete_app(app_id: str):
 async def get_workflow_urls(app_name: str):
     try:
         workspace = await run_modal_command("modal profile current")
-        edit_url = f"https://{workspace}--{app_name}-get-tunnel-url.modal.run"
+        edit_url = f"https://{workspace}--{app_name}-editingworkflow-ui.modal.run"
         run_url = f"https://{workspace}--{app_name}-comfyworkflow-ui.modal.run"
 
-        logger.info("GET request to url %s", edit_url)
+        result = {
+            "run_url": run_url,
+            "edit_url": f"{edit_url}?edit_workflow=true"
+        }
 
-        # Set a 30-second timeout
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(edit_url)
-            response.raise_for_status()
-            result = response.json()
-            result["run_url"] = run_url
-            result["edit_url"] = f"{result['edit_url']}?edit_workflow=true"
-            logger.info("Tunnel url %s", result)
-            logger.info("Run url %s", run_url)
-            return result
-    except httpx.ReadTimeout as e:
-        logger.error(
-            "Request timed out while making a request to %s", e.request.url)
-        raise HTTPException(
-            status_code=504, detail="Request timed out while fetching edit URL") from e
-    except httpx.HTTPError as e:
-        logger.error("HTTP %d %s error occurred while making a request to %s",
-                     response.status_code, response.reason_phrase, e.request.url)
-        raise HTTPException(
-            status_code=500, detail=f"Failed to fetch edit URL: {str(e)}") from e
+        logger.info("Workflow URLs: %s", result)
+        return result
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
         raise HTTPException(

--- a/backend/src/template/comfy_config.py
+++ b/backend/src/template/comfy_config.py
@@ -10,13 +10,17 @@ dependencies_str = default_dependencies if not additional_dependencies else f"{d
 dependencies: list[str] = [item.strip()
                            for item in dependencies_str.split(',')]
 
-comfyui_image = (Image.debian_slim(python_version="3.10")
-                 .apt_install("git")
-                 .pip_install(dependencies)
-                 .run_commands("comfy --skip-prompt install --nvidia")
-                 .run_commands("rm -rf /root/comfy/ComfyUI/models")
-                 .copy_local_dir(f"{current_directory}/comfyrun", "/root/comfy/ComfyUI/custom_nodes/comfyrun")
-                 .copy_local_file(f"{current_directory}/custom_nodes.json", "/root/")
-                 .run_commands("comfy --skip-prompt node install-deps --deps=/root/custom_nodes.json")
-                 .copy_local_file(f"{current_directory}/models.json", "/root/")
-                 )
+
+def create_comfyui_image(use_nvidia: bool = True):
+    install_command = "comfy --skip-prompt install --nvidia" if use_nvidia else "comfy --skip-prompt install --cpu"
+
+    return (Image.debian_slim(python_version="3.10")
+            .apt_install("git")
+            .pip_install(dependencies)
+            .run_commands(install_command)
+            .run_commands("rm -rf /root/comfy/ComfyUI/models")
+            .copy_local_dir(f"{current_directory}/comfyrun", "/root/comfy/ComfyUI/custom_nodes/comfyrun")
+            .copy_local_file(f"{current_directory}/custom_nodes.json", "/root/")
+            .run_commands("comfy --skip-prompt node install-deps --deps=/root/custom_nodes.json")
+            .copy_local_file(f"{current_directory}/models.json", "/root/")
+            )

--- a/backend/src/template/run_workflow.py
+++ b/backend/src/template/run_workflow.py
@@ -7,16 +7,16 @@ from config import config
 from modal import (App, web_server, Secret, build)
 from helpers import (models_volume, MODELS_PATH,
                      download_models, unzip_insight_face_models)
-from comfy_config import comfyui_image
+from comfy_config import create_comfyui_image
 
 machine_name = config["machine_name"]
 gpu_config = config["gpu"]
 idle_timeout = config["idle_timeout"]
 
-
+image = create_comfyui_image(use_nvidia=True)
 app = App(
     machine_name,
-    image=comfyui_image,
+    image=image,
     volumes={
         MODELS_PATH: models_volume
     },
@@ -26,7 +26,7 @@ app = App(
 
 @app.cls(
     gpu=gpu_config,
-    image=comfyui_image,
+    image=image,
     timeout=idle_timeout,
     container_idle_timeout=idle_timeout,
     allow_concurrent_inputs=100,

--- a/web/app/routes/app.$appName.edit/route.tsx
+++ b/web/app/routes/app.$appName.edit/route.tsx
@@ -47,6 +47,7 @@ export default function AppEditPage() {
   const data = useLoaderData<typeof loader>();
   const [isIframeLoaded, setIsIframeLoaded] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
+  const [showAlert, setShowAlert] = useState(true);
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -111,23 +112,29 @@ export default function AppEditPage() {
             </div>
           </DialogContent>
         </Dialog>
-        {isIframeLoaded && (
+        {isIframeLoaded && showAlert && (
           <div className="absolute top-4 left-4 right-4 z-10">
             <Alert variant="default" className="pr-12 relative">
               <AlertTitle>Heads up!</AlertTitle>
               <AlertDescription>
-                You can use this page to edit your workflows. It runs on CPU to
-                avoid GPU costs while editing your workflows. Please save the
-                workflow file before closing the page.
+                You can only quickly edit your workflows on this page as it runs
+                on CPU. Use this{" "}
+                <Link
+                  to={data.runUrl}
+                  className="underline"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  link
+                </Link>{" "}
+                to run your workflows on GPUs.
                 <br />
-                Use the Run button to open a new tab where you can run your
-                workflows on GPUs.
+                <br />
+                Note: Remember to save the workflow file before closing the
+                page.
               </AlertDescription>
               <button
-                onClick={() => {
-                  const alert = document.querySelector(".alert");
-                  if (alert) alert.remove();
-                }}
+                onClick={() => setShowAlert(false)}
                 className="absolute top-2 right-2 p-1 rounded-full hover:bg-gray-200 transition-colors"
                 aria-label="Close alert"
               >


### PR DESCRIPTION
**Changes:**
Earlier edit workflows were running on cpu containers and exposed via tunnels. However, it wasn't very reliable to get those urls and render them within iframe in the `edit` page of the app. This PR updates the `editing_workflow` to directly run ComfyUI server on CPU container without using tunnels as it in itself is way faster to boot up and run. 

