### PR TITLE
Feat: Auto select models from workflow file

### DIFF
--- a/web/app/components/custom-node-form.tsx
+++ b/web/app/components/custom-node-form.tsx
@@ -17,7 +17,7 @@ import {
   PopoverTrigger,
 } from "~/components/ui/popover";
 import { useEffect, useState } from "react";
-import { CustomNode } from "~/lib/types";
+import { CustomNode, Model } from "~/lib/types";
 
 import { Check, ChevronsUpDown } from "lucide-react";
 import { cn } from "~/lib/utils";
@@ -34,6 +34,7 @@ export interface CustomNodeFormProps {
   selectedCustomNodes: CustomNode[];
   onNodesSelected: (node: CustomNode[]) => void;
   onNodesGeneratedFromWFFile: (node: CustomNode[]) => void;
+  onModelsGeneratedFromWFFile: (models: Model[]) => void;
   onNextStep: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 export default function CustomNodeForm({
@@ -41,6 +42,7 @@ export default function CustomNodeForm({
   selectedCustomNodes,
   onNodesSelected,
   onNodesGeneratedFromWFFile,
+  onModelsGeneratedFromWFFile,
   onNextStep,
 }: CustomNodeFormProps) {
   const uploadWFFetcher = useFetcher<typeof action>({
@@ -66,6 +68,7 @@ export default function CustomNodeForm({
           <div className="sm:col-span-4">
             <UploadWorkflowFileForm
               onNodesGeneratedFromWFFile={onNodesGeneratedFromWFFile}
+              onModelsGeneratedFromWFFile={onModelsGeneratedFromWFFile}
             />
           </div>
           <div className="relative sm:col-span-4">
@@ -194,10 +197,12 @@ function CustomNodesComboBox({
 
 interface UploadWorkflowFileFormProps {
   onNodesGeneratedFromWFFile: (nodes: CustomNode[]) => void;
+  onModelsGeneratedFromWFFile: (models: Model[]) => void;
 }
 
 function UploadWorkflowFileForm({
   onNodesGeneratedFromWFFile,
+  onModelsGeneratedFromWFFile,
 }: UploadWorkflowFileFormProps) {
   const fetcher = useFetcher<typeof action>({ key: UPLOAD_WF_FETCHER_KEY });
 
@@ -215,9 +220,10 @@ function UploadWorkflowFileForm({
   useEffect(() => {
     if (
       fetcher.data?.result === "success" &&
-      (fetcher.data.data.length ?? 0 > 0)
+      (fetcher.data.data.nodes.length ?? 0 > 0)
     ) {
-      onNodesGeneratedFromWFFile(fetcher.data.data ?? []);
+      onNodesGeneratedFromWFFile(fetcher.data.data.nodes ?? []);
+      onModelsGeneratedFromWFFile(fetcher.data.data.models ?? []);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -288,7 +294,9 @@ function UploadWorkflowFileForm({
       fetcher.data?.result === "success" &&
       fetcher?.data?.data ? (
         <p className="text-sm mt-2">
-          <span className="font-semibold">{fetcher?.data?.data.length}</span>
+          <span className="font-semibold">
+            {fetcher?.data?.data.nodes?.length}
+          </span>
           <span> nodes selected from the workflow file</span>
         </p>
       ) : null}

--- a/web/app/components/models-form.tsx
+++ b/web/app/components/models-form.tsx
@@ -41,6 +41,7 @@ export interface ModelsFormProps {
   selectedComfyUIModels: Model[];
   selectedCivitAIModels: Model[];
   selectedCustomModels: Model[];
+  selectedModelsFromWFFile: Model[];
   onComfyUIModelsSelected: (model: Model[]) => void;
   onCivitAIModelsSelected: (model: Model[]) => void;
   onCustomModelAdded: (model: Model) => void;
@@ -48,11 +49,15 @@ export interface ModelsFormProps {
   onBackStep: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
+import { useState } from "react";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
+
 export default function ModelsForm({
   models,
   selectedComfyUIModels,
   selectedCivitAIModels,
   selectedCustomModels,
+  selectedModelsFromWFFile,
   onComfyUIModelsSelected,
   onCivitAIModelsSelected,
   onCustomModelAdded,
@@ -66,9 +71,57 @@ export default function ModelsForm({
   }, []);
 
   const [skipModelsDownload, setSkipModelsDownload] = useState<boolean>(false);
+  const [isWFFileSectionOpen, setIsWFFileSectionOpen] = useState<boolean>(true);
+
   return (
     <div>
       <div className="px-4 py-6 sm:p-8">
+        {selectedModelsFromWFFile.length > 0 && (
+          <div className="mb-4 p-4 border border-gray-300 rounded-md">
+            <div
+              className="flex justify-between items-center cursor-pointer"
+              onClick={() => setIsWFFileSectionOpen(!isWFFileSectionOpen)}
+            >
+              <span className="font-semibold text-sm">
+                Models selected from workflow file
+              </span>
+              {isWFFileSectionOpen ? (
+                <ChevronUpIcon className="h-5 w-5" />
+              ) : (
+                <ChevronDownIcon className="h-5 w-5" />
+              )}
+            </div>
+            {isWFFileSectionOpen && (
+              <>
+                <ul className="mt-2 text-sm text-gray-700">
+                  {selectedModelsFromWFFile.map((model) => (
+                    <li
+                      key={model.url + model.name}
+                      className="flex items-center"
+                    >
+                      <span className="mr-2">•</span>
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <span className="cursor-pointer underline">
+                            {model.name}
+                          </span>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-96">
+                          <p className="text-sm">{model.description}</p>
+                        </PopoverContent>
+                      </Popover>
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-2 text-sm text-gray-500">
+                  Note: The auto-selected models from the workflow file may not
+                  always be 100% accurate. Please review and add missing models
+                  manually if needed.
+                </p>
+              </>
+            )}
+          </div>
+        )}
         <div className="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
           <div className="sm:col-span-4">
             <Label>Add Models from ComfyUIManager</Label>
@@ -142,7 +195,8 @@ export default function ModelsForm({
             selectedCivitAIModels.length === 0 &&
             selectedComfyUIModels.length === 0 &&
             selectedCustomModels.length === 0 &&
-            !skipModelsDownload
+            !skipModelsDownload &&
+            selectedModelsFromWFFile.length === 0
           }
         >
           Next

--- a/web/app/components/models-form.tsx
+++ b/web/app/components/models-form.tsx
@@ -34,7 +34,11 @@ import { Model } from "~/lib/types";
 import { cn, isValidModelFileName, isValidModelUrl } from "~/lib/utils";
 import { CivitAIModelComboBox, loader } from "~/routes/civitai-search/route";
 import { Link, useFetcher } from "@remix-run/react";
-import { InformationCircleIcon } from "@heroicons/react/24/outline";
+import {
+  InformationCircleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/react/24/outline";
 
 export interface ModelsFormProps {
   models: Model[];
@@ -48,9 +52,6 @@ export interface ModelsFormProps {
   onNextStep: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   onBackStep: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
-
-import { useState } from "react";
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 
 export default function ModelsForm({
   models,

--- a/web/app/lib/types.ts
+++ b/web/app/lib/types.ts
@@ -112,3 +112,8 @@ export interface TimeInterval {
 export type APIResponse<T> =
   | { result: "success"; data: T }
   | { result: "error"; error: string };
+
+export type UploadWorkflowFileResponse = {
+  nodes: CustomNode[];
+  models: Model[];
+};

--- a/web/app/routes/create-app/route.tsx
+++ b/web/app/routes/create-app/route.tsx
@@ -101,6 +101,10 @@ export default function CreateAppPage() {
   );
   const [selectedCustomNodesFromWFFile, setSelectedCustomNodesFromWFFile] =
     useState<CustomNode[]>([]);
+
+  const [selectedModelsFromWFFile, setSelectedModelsFromWFFile] = useState<
+    Model[]
+  >([]);
   const [selectedComfyUIModels, setSelectedComfyUIModels] = useState<Model[]>(
     []
   );
@@ -136,6 +140,10 @@ export default function CreateAppPage() {
 
   function updateSelectedCustomNodesFromWFFile(custom_nodes: CustomNode[]) {
     setSelectedCustomNodesFromWFFile(custom_nodes);
+  }
+
+  function updateSelectedModelsFromWFFile(models: Model[]) {
+    setSelectedModelsFromWFFile(models);
   }
 
   function updateSelectedComfyUIModels(models: Model[]) {
@@ -183,6 +191,7 @@ export default function CreateAppPage() {
                 nodes={custom_nodes}
                 onNodesSelected={updateSelectedCustomNodes}
                 onNodesGeneratedFromWFFile={updateSelectedCustomNodesFromWFFile}
+                onModelsGeneratedFromWFFile={updateSelectedModelsFromWFFile}
                 onNextStep={(e) => {
                   e.preventDefault();
                   updateSteps(steps, 1);
@@ -195,6 +204,7 @@ export default function CreateAppPage() {
                 selectedComfyUIModels={selectedComfyUIModels}
                 selectedCivitAIModels={selectedCivitaiModels}
                 selectedCustomModels={selectedCustomModels}
+                selectedModelsFromWFFile={selectedModelsFromWFFile}
                 onComfyUIModelsSelected={updateSelectedComfyUIModels}
                 onCivitAIModelsSelected={updateSelectedCivitaiModels}
                 onCustomModelAdded={onCustomModelAdded}
@@ -219,6 +229,7 @@ export default function CreateAppPage() {
                     selectedCivitaiModels
                       .concat(selectedComfyUIModels)
                       .concat(selectedCustomModels)
+                      .concat(selectedModelsFromWFFile)
                   )}
                   onBackStep={(e) => {
                     e.preventDefault();

--- a/web/app/routes/upload-workflow-file/route.tsx
+++ b/web/app/routes/upload-workflow-file/route.tsx
@@ -1,5 +1,5 @@
 import { ActionFunctionArgs } from "@remix-run/node";
-import { CustomNode } from "~/lib/types";
+import { CustomNode, Model, UploadWorkflowFileResponse } from "~/lib/types";
 import { sendErrorResponse, sendSuccessResponse } from "~/server/utils";
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -12,30 +12,34 @@ export async function action({ request }: ActionFunctionArgs) {
       body: formData,
     });
     if (!response.ok) {
-      return sendErrorResponse<CustomNode[]>(
+      return sendErrorResponse<UploadWorkflowFileResponse>(
         "Unable to fetch custom nodes from workflow file",
         response.status
       );
     }
 
-    const custom_nodes = await response.json();
-    const nodes: CustomNode[] = custom_nodes.map(
+    const data = await response.json();
+    const nodes: CustomNode[] = data.custom_nodes.map(
       (custom_node: string): CustomNode => ({
         reference: custom_node,
       })
     );
+    const models: Model[] = data.models;
 
     if (nodes.length === 0) {
-      return sendErrorResponse<CustomNode[]>(
+      return sendErrorResponse<UploadWorkflowFileResponse>(
         "No custom nodes found in the uploaded workflow file",
         400
       );
     }
 
-    return sendSuccessResponse<CustomNode[]>(nodes, 200);
+    return sendSuccessResponse<UploadWorkflowFileResponse>(
+      { nodes, models },
+      200
+    );
   } catch (error) {
     console.error("upload-workflow-file API error", error);
-    return sendErrorResponse<CustomNode[]>(
+    return sendErrorResponse<UploadWorkflowFileResponse>(
       "Unable to fetch custom nodes from workflow file",
       500
     );


### PR DESCRIPTION
**Changes:**
We auto select list of custom nodes if user uploads their workflow file when creating the app. Similarly, we can auto select list of models using the same uploaded workflow file. This PR adds the change to find the list of models(`.safetensors`, `.bin`) used from workflow json by doing a reverse look up in our model-list json. 

> Please note that this doesn't always accurately finds out the the list of models used in a workflow. It is still a useful feature when it works! 😉 


**UI**

<img width="1122" alt="Screenshot 2024-09-01 at 6 14 21 PM" src="https://github.com/user-attachments/assets/c7361f19-973e-429c-8999-6f3db974868e">


