### PR TITLE
Fix: model filename validation when creating app

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -19,7 +19,7 @@ class Model(BaseModel):
     name: str
     url: HttpUrl
     path: str
-    filename: Optional[str]
+    filename: Optional[str] = None
 
 
 class Gpu(str, Enum):

--- a/backend/src/template/helpers.py
+++ b/backend/src/template/helpers.py
@@ -25,7 +25,7 @@ def download_models(models, civitai_token) -> bool:
         model_name = model["name"]
         download_url = model["url"]
         download_path = model["path"]
-        file_name = model.get("filename", download_url.split("/")[-1])
+        file_name = model.get("filename") or download_url.split("/")[-1]
         print(f"file_name: {file_name}")
         if file_name in common_model_names:
             checkpoint_path: Path = Path(


### PR DESCRIPTION
**Issue:**
When adding models via HuggingFace we don't provide model's filename when creating the app as this field is kept optional. However, on BE we didn't provide default value to this optional field causing request validation error

**Fix:**
- Added default value of None to `filename` 
- Added custom exception handler to log such request validation exceptions by FastAPI. This would make it easier to debug such errors by looking at logs
- Updated download helper running inside Modal to account for `filename=None` value

